### PR TITLE
Added vanilla expanded headgear to power armor station

### DIFF
--- a/1.3/Defs/ThingDefs_Buildings/Buildings_Misc.xml
+++ b/1.3/Defs/ThingDefs_Buildings/Buildings_Misc.xml
@@ -73,6 +73,10 @@
           <li MayRequire="VanillaExpanded.VARME">VAE_Apparel_TrooperArmor</li>
           <li MayRequire="VanillaExpanded.VARME">VAE_Apparel_HeavyMarineArmor</li>
           <li MayRequire="VanillaExpanded.VARME">VAE_Handwear_MarineGloves</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_HeavyMarineHelmet</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_TrooperHelmet</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_RoyalSiegeHelmet</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_RoyalTrooperHelmet</li>
           <li MayRequire="Hlx.UltratechAlteredCarbon">UT_Apparel_ProtectorateArmor</li>
           <li MayRequire="Hlx.UltratechAlteredCarbon">UT_Apparel_ProtectorateArmorHelmet</li>
           <li MayRequire="kentington.saveourship2">Apparel_SpaceSuitBodyHeavy</li>

--- a/1.4/Defs/ThingDefs_Buildings/Buildings_Misc.xml
+++ b/1.4/Defs/ThingDefs_Buildings/Buildings_Misc.xml
@@ -73,6 +73,10 @@
           <li MayRequire="VanillaExpanded.VARME">VAE_Apparel_TrooperArmor</li>
           <li MayRequire="VanillaExpanded.VARME">VAE_Apparel_HeavyMarineArmor</li>
           <li MayRequire="VanillaExpanded.VARME">VAE_Handwear_MarineGloves</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_HeavyMarineHelmet</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_TrooperHelmet</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_RoyalSiegeHelmet</li>
+          <li MayRequire="VanillaExpanded.VARME">VAE_Headgear_RoyalTrooperHelmet</li>
           <li MayRequire="kentington.saveourship2">Apparel_SpaceSuitBodyHeavy</li>
           <li MayRequire="kentington.saveourship2">Apparel_SpaceSuitHelmetHeavy</li>
           <li MayRequire="Mlie.RimworldSpartanFoundry">SF_PoweredAssaultArmor</li>


### PR DESCRIPTION
Noticed that the vanilla expanded power armor headgear was missing from power armor station. I added them to the Buildings_Misc.xml defs.